### PR TITLE
query_log_file pro

### DIFF
--- a/prometheus/types.go
+++ b/prometheus/types.go
@@ -202,6 +202,8 @@ type GlobalConfig struct {
 	EvaluationInterval string `yaml:"evaluation_interval,omitempty"`
 	// The labels to add to any timeseries that this Prometheus instance scrapes.
 	ExternalLabels map[string]string `yaml:"external_labels,omitempty"`
+	// Logging all the queries to a file.
+	QueryLogFile string `yaml:"query_log_file,omitempty"
 }
 
 // Config is the top-level configuration for Prometheus's config files.


### PR DESCRIPTION
Prometheus has the ability to log all the queries run by the engine to a log file, as of 2.16.0. This guide demonstrates how to use that log file, which fields it contains, and provides advanced tips about how to operate the log file.